### PR TITLE
Fix sign error in derivative output

### DIFF
--- a/derivatives.qmd
+++ b/derivatives.qmd
@@ -161,7 +161,7 @@ $$
 Then, the output of the derivative operator is:
 
 $$
-\mathbf{r}=\mathbf{D_0} \boldsymbol\ell=\left[0, -1, 0, 2\right]
+\mathbf{r}=\mathbf{D_0} \boldsymbol\ell=\left[0, 1, 0, -2\right]
 $$
 Note that this vector has one sample less than the input. To recover the input $\boldsymbol\ell$ we cannot invert $\mathbf{D_0}$ as it is not a square matrix, but we can compute the pseudoinverse, which turns out to be:
 


### PR DESCRIPTION
There is a sign error in the derivation, this PR fixes it, the other equations in the section are correct.

- See the python code below. 
- The PR https://github.com/Foundations-of-Computer-Vision/visionbook/pull/49/commits/fc7b84c8a0217f262e171a4be708bb7405bc761c also concerns this but only fixes one sign, not both. 

```
import numpy as np

# Define the 5x5 matrix - you can change these values
D = np.array([
 #   [1.0, .0, .0, .0, .0],
    [-1.0, 1.0, .0, .0, .0],
    [.0, -1.0, 1.0, .0, .0],
    [.0, .0, -1.0, 1.0, .0],
    [.0, .0, .0, -1.0, 1.0]
])

# Define the 5x1 vector - you can change these values
l = np.array([
    [1.0],
    [1.0],
    [2.0],
    [2.0],
    [0.0]
])

# Compute the matrix-vector product: r = D * l
r = D @ l

invD = np.linalg.pinv(D)
lhat = invD @ r


print("Matrix D (5x5):")
print(D)
print("Matrix 5* inv D (5x5):")
print(5*np.round(invD,1))
print("\nSignal l (5x1):")
print(l)
print("\nProduct r = D * l:")
print(r)
print("\nProduct lhat = pinv(D) * t:")
print(np.round(lhat, 1))
```

with output: 
```
Matrix D (5x5):
[[-1.  1.  0.  0.  0.]
 [ 0. -1.  1.  0.  0.]
 [ 0.  0. -1.  1.  0.]
 [ 0.  0.  0. -1.  1.]]
Matrix 5* inv D (5x5):
[[-4. -3. -2. -1.]
 [ 1. -3. -2. -1.]
 [ 1.  2. -2. -1.]
 [ 1.  2.  3. -1.]
 [ 1.  2.  3.  4.]]

Signal l (5x1):
[[1.]
 [1.]
 [2.]
 [2.]
 [0.]]

Product r = D * l:
[[ 0.]
 [ 1.]
 [ 0.]
 [-2.]]

Product lhat = pinv(D) * t:
[[-0.2]
 [-0.2]
 [ 0.8]
 [ 0.8]
 [-1.2]]
```
