### PR TITLE
Update generative_models.qmd

### DIFF
--- a/generative_models.qmd
+++ b/generative_models.qmd
@@ -897,8 +897,8 @@ as a minimax game: $$\begin{aligned}
 \end{aligned}$${#eq-generative_models-GAN_learning_problem}
 
 Schematically, the generator synthesizes images that are then fed as
-input to the discriminator. The discriminator tries to assign a high
-score to generated images (classifying them as synthetic) and a low
+input to the discriminator. The discriminator tries to assign a low
+score to generated images (classifying them as synthetic) and a high
 score to real images from some training set (classifying them as real),
 as shown in @fig-generative_models-generative_models-gan_schematic.
 


### PR DESCRIPTION
According to Eq. (32.6), the discriminator actually tries to assign  "low" scores to generated images, while assign "high" scores to real images.  The scores (0.9 and 0.1) in Figure 32.16 should also be swapped.